### PR TITLE
add infix comments and enforce two semicolons for comments

### DIFF
--- a/src/read_wat.c
+++ b/src/read_wat.c
@@ -55,10 +55,31 @@ void web49_readwat_skip(web49_io_input_t *in) {
             continue;
         }
         if (first == ';') {
+            first = web49_io_input_fgetc(in);
+            if (first != ';') {
+                web49_io_input_rewind(in);
+                break;
+            }
             while (first != '\n') {
                 first = web49_io_input_fgetc(in);
             }
             continue;
+        }
+        if (first == '(') {
+            first = web49_io_input_fgetc(in);
+            if (first == ';') {
+                while (true) {
+                    first = web49_io_input_fgetc(in);
+                    if (first == ';') {
+                        first = web49_io_input_fgetc(in);
+                        if (first == ')') {
+                            break;
+                        }
+                    }
+                }
+                continue;
+            }
+            web49_io_input_rewind(in);
         }
         web49_io_input_rewind(in);
         break;


### PR DESCRIPTION
Infix comments such as `(;0;)` are treated as whitespace.
Double semicolons are also now enforced, but while it will give you an error for not having two semicolons the error is not particularly helpful.

Errors seem to be in progress in general so I'm requesting commentary on how you want to handle this kind of thing.

Testing is also busted at the moment, on my machine, (including hangs and maybe memory leaks?) so I request testing from somebody who has working tests.
